### PR TITLE
Replaced "tabs" manifest permission with "activeTab"

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -17,6 +17,6 @@
    },
    "name": "Copy HTML Link",
   
-   "permissions": [ "tabs" ],
+   "permissions": [ "activeTab" ],
    "version": "1.0"
 }


### PR DESCRIPTION
As you can read at https://developer.chrome.com/extensions/activeTab#what-activeTab-allows, while the activeTab permission is enabled for a tab, an extension can get the URL, title, and favicon for that tab via an API that returns a tabs.Tab object.
